### PR TITLE
updated version of bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ name = "bindgen-tutorial-bzip2-sys"
 version = "0.1.0"
 
 [build-dependencies]
-bindgen = "0.26.3"
+bindgen = "0.32.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ name = "bindgen-tutorial-bzip2-sys"
 version = "0.1.0"
 
 [build-dependencies]
-bindgen = "0.32.1"
+bindgen = "*"


### PR DESCRIPTION
Version in the current master branch didn't work on ubuntu 16.04 and current rust compiler. It created "undefined reference to" errors.